### PR TITLE
Capture actions of relative paths too

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight eBPF program to monitor file creation and modification events on L
 - **CO-RE Support**: Designed to work with Compile Once – Run Everywhere (CO-RE) on kernels that support it (Kernel 5.x+).
 - **Configurable Filtering**: Filter events by file path, action, or user via a simple YAML configuration.
 - **Low Noise**: Filters events in the kernel before they reach userspace, reducing overhead.
+- **Absolute/Relative paths** - Whether user access the sensitive file over relative/absolute paths ie., `testfile` by switching to `/tmp` in addition to accessing directly `/tmp/testfile`
 
 ## Prerequisites
 


### PR DESCRIPTION
- Whether user access the sensitive file over relative/absolute paths ie., `testfile` by switching to `/tmp` in addition to accessing directly `/tmp/testfile`
- Following feedback from https://www.reddit.com/r/eBPF/comments/1q2qsfy/comment/nxexuaz/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
- Logs from testing
```text
root@raspberrypi-dr:/tmp# ./fim-ebpf-linux-arm64 
2026/01/03 10:16:36 Monitoring started. Ctrl+C to exit.
2026/01/03 10:16:39 Event: PID=1494437 UID=1000 (1000 (pi)) CMD=touch FILE=testfile ACTION=OPEN FLAGS=00000941
2026/01/03 10:16:45 Event: PID=1494457 UID=1000 (1000 (pi)) CMD=rm FILE=testfile ACTION=DELETE FLAGS=00000000
2026/01/03 10:16:50 Event: PID=1494505 UID=1000 (1000 (pi)) CMD=touch FILE=/tmp/testfile ACTION=OPEN FLAGS=00000941
2026/01/03 10:16:56 Event: PID=1494545 UID=1000 (1000 (pi)) CMD=rm FILE=/tmp/testfile ACTION=DELETE FLAGS=00000000
```